### PR TITLE
CO-1463 create service-tg sub module for using a single alb per service in stack

### DIFF
--- a/iam-role/main.tf
+++ b/iam-role/main.tf
@@ -41,9 +41,11 @@ resource "aws_iam_role_policy" "default_ecs_service_role_policy" {
       "Action": [
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:Describe*",
-        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
         "elasticloadbalancing:Describe*",
-        "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:RegisterTargets"
       ],
       "Resource": "*"
     }

--- a/service-tg/main.tf
+++ b/service-tg/main.tf
@@ -55,30 +55,8 @@ variable "log_bucket" {
   description = "The S3 bucket ID to use for the tg-listner"
 }
 
-variable "ssl_certificate_id" {
-  description = "SSL Certificate ID to use"
-}
-
 variable "iam_role" {
   description = "IAM Role ARN to use"
-}
-
-variable "external_dns_name" {
-  description = "The subdomain under which the tg-listner is exposed externally, defaults to the task name"
-  default     = ""
-}
-
-variable "internal_dns_name" {
-  description = "The subdomain under which the tg-listner is exposed internally, defaults to the task name"
-  default     = ""
-}
-
-variable "external_zone_id" {
-  description = "The zone ID to create the record in"
-}
-
-variable "internal_zone_id" {
-  description = "The zone ID to create the record in"
 }
 
 /**

--- a/service-tg/main.tf
+++ b/service-tg/main.tf
@@ -17,22 +17,26 @@
  * Required Variables.
  */
 
-variable "environment" {
-  description = "Environment tag, e.g prod"
+variable "name" {
+   description = "The service name, if empty the service name is defaulted to the image name"
+   default     = ""
+}
+
+variable "cluster" {
+  description = "The cluster name or ARN"
+}
+
+variable "iam_role" {
+  description = "IAM Role ARN to use"
+}
+
+variable "container_port" {
+  description = "The container port"
+  default     = 3000
 }
 
 variable "image" {
   description = "The docker image name, e.g nginx"
-}
-
-variable "name" {
-  description = "The service name, if empty the service name is defaulted to the image name"
-  default     = ""
-}
-
-variable "protocol" {
-  description = "Protocol to use, HTTP or TCP"
-  default = "HTTP"
 }
 
 variable "version" {
@@ -40,42 +44,60 @@ variable "version" {
   default     = "latest"
 }
 
-variable "subnet_ids" {
-  description = "Comma separated list of subnet IDs that will be passed to the tg-listner module"
+variable "protocol" {
+  description = "Protocol to use, HTTP or TCP"
+  default = "HTTP"
 }
 
-variable "security_groups" {
-  description = "Comma separated list of security group IDs that will be passed to the tg-listner module"
+variable "vpc_id" {
+  description = "The id of the VPC."
 }
 
 variable "port" {
   description = "The container host port"
 }
 
-variable "cluster" {
-  description = "The cluster name or ARN"
+variable "priority" {
+  description = "The priority for the rule. A listener can't have multiple rules with the same priority"
 }
 
-variable "log_bucket" {
-  description = "The S3 bucket ID to use for the tg-listner"
+variable "condition_values" {
+  description = "Listner rule condition. This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
+  type = "string"
 }
 
-variable "iam_role" {
-  description = "IAM Role ARN to use"
+variable "listener_arn_80" {
+  description = "arn of an aws_alb_listener"
+  type = "string"
+}
+
+variable "listener_arn_443" {
+  description = "arn of an aws_alb_listener"
+  type = "string"
+}
+
+variable "tags" {
+  description = "tags for the distribution"
+  type        = "map"
+  description = "tags, just tags"
 }
 
 /**
  * Options.
  */
-
-variable "healthcheck" {
-  description = "Path to a healthcheck endpoint"
-  default     = "/"
+variable "desired_count" {
+ description = "The desired count"
+ default     = 2
 }
 
-variable "container_port" {
-  description = "The container port"
-  default     = 3000
+variable "deployment_minimum_healthy_percent" {
+ description = "lower limit (% of desired_count) of # of running tasks during a deployment"
+ default     = 100
+}
+
+variable "deployment_maximum_percent" {
+ description = "upper limit (% of desired_count) of # of running tasks during a deployment"
+ default     = 200
 }
 
 variable "command" {
@@ -88,11 +110,6 @@ variable "env_vars" {
   default     = "[]"
 }
 
-variable "desired_count" {
-  description = "The desired count"
-  default     = 2
-}
-
 variable "memory" {
   description = "The number of MiB of memory to reserve for the container"
   default     = 512
@@ -103,87 +120,54 @@ variable "cpu" {
   default     = 512
 }
 
-variable "deployment_minimum_healthy_percent" {
-  description = "lower limit (% of desired_count) of # of running tasks during a deployment"
-  default     = 100
-}
-
-variable "deployment_maximum_percent" {
-  description = "upper limit (% of desired_count) of # of running tasks during a deployment"
-  default     = 200
-}
-
-variable "vpc_id" {
-  description = "The id of the VPC."
-}
-
 variable "health_check_protocol" {
   description = "The protocol that the load balancer uses when performing health checks on the targets. Accepts HTTP, HTTPS "
   type = "string"
   default = "HTTP"
 }
+
 variable "health_check_path" {
   description = "The ping path destination where Elastic Load Balancing sends health check requests"
   type = "string"
-  default = "/api/Heartbeats"
+  default = "/"
 }
+
 variable "health_check_port" {
   description = "The port to use to connect with the target. Valid values are either ports 1-65536, or traffic-port"
   type = "string"
   default = "traffic-port"
 }
+
 variable "health_check_healthy_threshold" {
   description = "The number of consecutive successful health checks that are required before an unhealthy target is considered healthy"
   default = 2
 }
+
 variable "health_check_unhealthy_threshold" {
   description = " The number of consecutive failed health checks that are required before a target is considered unhealthy"
   default = 2
 }
+
 variable "health_check_timeout" {
   description = "The number of seconds to wait for a response before considering that a health check has failed"
   default = 5
 }
+
 variable "health_check_interval" {
   description = "The approximate number of seconds between health checks for an individual target"
   default = 30
 }
+
 variable "health_check_matcher" {
   description = "The HTTP codes that a healthy target uses when responding to a health check. HTTP codes must be in Matcher data type"
   type = "string"
   default = "200-399"
 }
 
-variable "tags" {
-  description = "tags for the distribution"
-  type        = "map"
-  description = "tags, just tags"
-}
-
-//additional listener specific vars
-variable "priority" {
-  description = "The priority for the rule. A listener can't have multiple rules with the same priority"
-}
-
 variable "condition_field" {
   description = "The name of the field. Must be one of path-pattern for path based routing or host-header for host based routing. Accepts path-pattern, host-header"
   type = "string"
   default = "host-header"
-}
-
-variable "condition_values" {
-  description = "This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
-  type = "string"
-}
-
-variable "listener_arn_80" {
-  description = "arn of an aws_alb_listener"
-  type = "string"
-}
-
-variable "listener_arn_443" {
-  description = "arn of an aws_alb_listener"
-  type = "string"
 }
 
 /**
@@ -236,7 +220,6 @@ module "tg-listner" {
   source = "../tg-listner"
 
   name                             = "${module.task.name}"
-  environment                      = "${var.environment}"
   port                             = "${var.port}"
   protocol                         = "${var.protocol}"
   vpc_id                           = "${var.vpc_id}"
@@ -251,9 +234,9 @@ module "tg-listner" {
   priority                         = "${var.priority}"
   condition_field                  = "${var.condition_field}"
   condition_values                 = "${var.condition_values}"
-  tags                             = "${var.tags}"
   listener_arn_80                  = "${var.listener_arn_80}"
   listener_arn_443                 = "${var.listener_arn_443}"
+  tags                             = "${var.tags}"
 }
 
 /**

--- a/service-tg/main.tf
+++ b/service-tg/main.tf
@@ -30,6 +30,11 @@ variable "name" {
   default     = ""
 }
 
+variable "protocol" {
+  description = "Protocol to use, HTTP or TCP"
+  default = "HTTP"
+}
+
 variable "version" {
   description = "The docker image version"
   default     = "latest"

--- a/service-tg/main.tf
+++ b/service-tg/main.tf
@@ -117,6 +117,43 @@ variable "vpc_id" {
   description = "The id of the VPC."
 }
 
+variable "health_check_protocol" {
+  description = "The protocol that the load balancer uses when performing health checks on the targets. Accepts HTTP, HTTPS "
+  type = "string"
+  default = "HTTP"
+}
+variable "health_check_path" {
+  description = "The ping path destination where Elastic Load Balancing sends health check requests"
+  type = "string"
+  default = "/api/Heartbeats"
+}
+variable "health_check_port" {
+  description = "The port to use to connect with the target. Valid values are either ports 1-65536, or traffic-port"
+  type = "string"
+  default = "traffic-port"
+}
+variable "health_check_healthy_threshold" {
+  description = "The number of consecutive successful health checks that are required before an unhealthy target is considered healthy"
+  default = 2
+}
+variable "health_check_unhealthy_threshold" {
+  description = " The number of consecutive failed health checks that are required before a target is considered unhealthy"
+  default = 2
+}
+variable "health_check_timeout" {
+  description = "The number of seconds to wait for a response before considering that a health check has failed"
+  default = 5
+}
+variable "health_check_interval" {
+  description = "The approximate number of seconds between health checks for an individual target"
+  default = 30
+}
+variable "health_check_matcher" {
+  description = "The HTTP codes that a healthy target uses when responding to a health check. HTTP codes must be in Matcher data type"
+  type = "string"
+  default = "200-399"
+}
+
 /**
  * Resources.
  */

--- a/service-tg/main.tf
+++ b/service-tg/main.tf
@@ -1,6 +1,6 @@
 /**
  * The web-service is similar to the `service` module, but the
- * it provides a tg-listner rule instead.
+ * it provides a tg-listener rule instead.
  *
  * Usage:
  *
@@ -62,7 +62,7 @@ variable "priority" {
 }
 
 variable "condition_values" {
-  description = "Listner rule condition. This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
+  description = "listener rule condition. This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
   type = "string"
 }
 
@@ -182,10 +182,10 @@ resource "aws_ecs_service" "main" {
   iam_role                           = "${var.iam_role}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
-  depends_on                         = ["module.tg-listner"]
+  depends_on                         = ["module.tg-listener"]
 
   load_balancer {
-    target_group_arn = "${module.tg-listner.arn}"
+    target_group_arn = "${module.tg-listener.arn}"
     container_name   = "${module.task.name}"
     container_port   = "${var.container_port}"
   }
@@ -216,8 +216,8 @@ module "task" {
 EOF
 }
 
-module "tg-listner" {
-  source = "../tg-listner"
+module "tg-listener" {
+  source = "../tg-listener"
 
   name                             = "${module.task.name}"
   port                             = "${var.port}"
@@ -243,12 +243,12 @@ module "tg-listner" {
  * Outputs.
  */
 
-// The name of the tg-listner
+// The name of the tg-listener
 output "name" {
-  value = "${module.tg-listner.name}"
+  value = "${module.tg-listener.name}"
 }
 
-// The arn of the tg-listner
+// The arn of the tg-listener
 output "arn" {
-  value = "${module.tg-listner.arn}"
+  value = "${module.tg-listener.arn}"
 }

--- a/service-tg/main.tf
+++ b/service-tg/main.tf
@@ -154,6 +154,38 @@ variable "health_check_matcher" {
   default = "200-399"
 }
 
+variable "tags" {
+  description = "tags for the distribution"
+  type        = "map"
+  description = "tags, just tags"
+}
+
+//additional listener specific vars
+variable "priority" {
+  description = "The priority for the rule. A listener can't have multiple rules with the same priority"
+}
+
+variable "condition_field" {
+  description = "The name of the field. Must be one of path-pattern for path based routing or host-header for host based routing. Accepts path-pattern, host-header"
+  type = "string"
+  default = "host-header"
+}
+
+variable "condition_values" {
+  description = "This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
+  type = "string"
+}
+
+variable "listener_arn_80" {
+  description = "arn of an aws_alb_listener"
+  type = "string"
+}
+
+variable "listener_arn_443" {
+  description = "arn of an aws_alb_listener"
+  type = "string"
+}
+
 /**
  * Resources.
  */
@@ -169,7 +201,7 @@ resource "aws_ecs_service" "main" {
   depends_on                         = ["module.tg-listner"]
 
   load_balancer {
-    target_group_arn = "${module.tg-listner.target_group}"
+    target_group_arn = "${module.tg-listner.arn}"
     container_name   = "${module.task.name}"
     container_port   = "${var.container_port}"
   }
@@ -220,6 +252,8 @@ module "tg-listner" {
   condition_field                  = "${var.condition_field}"
   condition_values                 = "${var.condition_values}"
   tags                             = "${var.tags}"
+  listener_arn_80                  = "${var.listener_arn_80}"
+  listener_arn_443                 = "${var.listener_arn_443}"
 }
 
 /**

--- a/service-tg/main.tf
+++ b/service-tg/main.tf
@@ -1,0 +1,233 @@
+/**
+ * The web-service is similar to the `service` module, but the
+ * it provides a __public__ ALB instead.
+ *
+ * Usage:
+ *
+ *      module "auth_service" {
+ *        source    = "github.com/segmentio/stack/service"
+ *        name      = "auth-service"
+ *        image     = "auth-service"
+ *        cluster   = "default"
+ *      }
+ *
+ */
+
+/**
+ * Required Variables.
+ */
+
+variable "environment" {
+  description = "Environment tag, e.g prod"
+}
+
+variable "image" {
+  description = "The docker image name, e.g nginx"
+}
+
+variable "name" {
+  description = "The service name, if empty the service name is defaulted to the image name"
+  default     = ""
+}
+
+variable "version" {
+  description = "The docker image version"
+  default     = "latest"
+}
+
+variable "subnet_ids" {
+  description = "Comma separated list of subnet IDs that will be passed to the ALB module"
+}
+
+variable "security_groups" {
+  description = "Comma separated list of security group IDs that will be passed to the ALB module"
+}
+
+variable "port" {
+  description = "The container host port"
+}
+
+variable "cluster" {
+  description = "The cluster name or ARN"
+}
+
+variable "log_bucket" {
+  description = "The S3 bucket ID to use for the ALB"
+}
+
+variable "ssl_certificate_id" {
+  description = "SSL Certificate ID to use"
+}
+
+variable "iam_role" {
+  description = "IAM Role ARN to use"
+}
+
+variable "external_dns_name" {
+  description = "The subdomain under which the ALB is exposed externally, defaults to the task name"
+  default     = ""
+}
+
+variable "internal_dns_name" {
+  description = "The subdomain under which the ALB is exposed internally, defaults to the task name"
+  default     = ""
+}
+
+variable "external_zone_id" {
+  description = "The zone ID to create the record in"
+}
+
+variable "internal_zone_id" {
+  description = "The zone ID to create the record in"
+}
+
+/**
+ * Options.
+ */
+
+variable "healthcheck" {
+  description = "Path to a healthcheck endpoint"
+  default     = "/"
+}
+
+variable "container_port" {
+  description = "The container port"
+  default     = 3000
+}
+
+variable "command" {
+  description = "The raw json of the task command"
+  default     = "[]"
+}
+
+variable "env_vars" {
+  description = "The raw json of the task env vars"
+  default     = "[]"
+}
+
+variable "desired_count" {
+  description = "The desired count"
+  default     = 2
+}
+
+variable "memory" {
+  description = "The number of MiB of memory to reserve for the container"
+  default     = 512
+}
+
+variable "cpu" {
+  description = "The number of cpu units to reserve for the container"
+  default     = 512
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "lower limit (% of desired_count) of # of running tasks during a deployment"
+  default     = 100
+}
+
+variable "deployment_maximum_percent" {
+  description = "upper limit (% of desired_count) of # of running tasks during a deployment"
+  default     = 200
+}
+
+variable "vpc_id" {
+  description = "The id of the VPC."
+}
+
+/**
+ * Resources.
+ */
+
+resource "aws_ecs_service" "main" {
+  name                               = "${module.task.name}"
+  cluster                            = "${var.cluster}"
+  task_definition                    = "${module.task.arn}"
+  desired_count                      = "${var.desired_count}"
+  iam_role                           = "${var.iam_role}"
+  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
+  depends_on                         = ["module.alb"]
+
+  load_balancer {
+    target_group_arn = "${module.alb.target_group}"
+    container_name   = "${module.task.name}"
+    container_port   = "${var.container_port}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+module "task" {
+  source = "../task"
+
+  name              = "${coalesce(var.name, replace(var.image, "/", "-"))}"
+  image             = "${var.image}"
+  image_version     = "${var.version}"
+  command           = "${var.command}"
+  env_vars          = "${var.env_vars}"
+  memory            = "${var.memory}"
+  cpu               = "${var.cpu}"
+
+  ports = <<EOF
+  [
+    {
+      "containerPort": ${var.container_port},
+      "hostPort": ${var.port}
+    }
+  ]
+EOF
+}
+
+module "alb" {
+  source = "../alb"
+
+  name               = "${module.task.name}"
+  port               = "${var.port}"
+  environment        = "${var.environment}"
+  subnet_ids         = "${var.subnet_ids}"
+  external_dns_name  = "${coalesce(var.external_dns_name, module.task.name)}"
+  internal_dns_name  = "${coalesce(var.internal_dns_name, module.task.name)}"
+  healthcheck        = "${var.healthcheck}"
+  external_zone_id   = "${var.external_zone_id}"
+  internal_zone_id   = "${var.internal_zone_id}"
+  security_groups    = "${var.security_groups}"
+  log_bucket         = "${var.log_bucket}"
+  ssl_certificate_id = "${var.ssl_certificate_id}"
+  vpc_id             = "${var.vpc_id}"
+}
+
+/**
+ * Outputs.
+ */
+
+// The name of the ALB
+output "name" {
+  value = "${module.alb.name}"
+}
+
+// The DNS name of the ALB
+output "dns" {
+  value = "${module.alb.dns}"
+}
+
+// The id of the ALB
+output "alb" {
+  value = "${module.alb.id}"
+}
+
+// The zone id of the ALB
+output "zone_id" {
+  value = "${module.alb.zone_id}"
+}
+
+// FQDN built using the zone domain and name (external)
+output "external_fqdn" {
+  value = "${module.alb.external_fqdn}"
+}
+
+// FQDN built using the zone domain and name (internal)
+output "internal_fqdn" {
+  value = "${module.alb.internal_fqdn}"
+}

--- a/tg-listener/main.tf
+++ b/tg-listener/main.tf
@@ -1,5 +1,5 @@
 /**
- * The tg-listner module creates an target group, and 2 listener rules
+ * The tg-listener module creates an target group, and 2 listener rules
  * It is used by the service-tg module.
  */
 

--- a/tg-listner/main.tf
+++ b/tg-listner/main.tf
@@ -1,0 +1,136 @@
+/**
+ * The tg-listner module creates an target group, and 2 listener rules
+ * It is used by the service-tg module.
+ */
+
+variable "name" {
+  description = "target group name, e.g cdn"
+}
+
+variable "environment" {
+  description = "Environment tag, e.g prod"
+}
+
+variable "port" {
+  description = "Instance port"
+}
+
+variable "protocol" {
+  description = "Protocol to use, HTTP or TCP"
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC in which your targets are located"
+}
+
+variable "health_check_protocol" {
+  description = "The protocol that the load balancer uses when performing health checks on the targets. Accepts HTTP, HTTPS "
+  type = "string"
+  default = "HTTP"
+}
+variable "health_check_path" {
+  description = "The ping path destination where Elastic Load Balancing sends health check requests"
+  type = "string"
+  default = "/api/Heartbeats"
+}
+variable "health_check_port" {
+  description = "The port to use to connect with the target. Valid values are either ports 1-65536, or traffic-port"
+  type = "string"
+  default = "traffic-port"
+}
+variable "health_check_healthy_threshold" {
+  description = "The number of consecutive successful health checks that are required before an unhealthy target is considered healthy"
+  default = 2
+}
+variable "health_check_unhealthy_threshold" {
+  description = " The number of consecutive failed health checks that are required before a target is considered unhealthy"
+  default = 2
+}
+variable "health_check_timeout" {
+  description = "The number of seconds to wait for a response before considering that a health check has failed"
+  default = 5
+}
+variable "health_check_interval" {
+  description = "The approximate number of seconds between health checks for an individual target"
+  default = 30
+}
+variable "health_check_matcher" {
+  description = "The HTTP codes that a healthy target uses when responding to a health check. HTTP codes must be in Matcher data type"
+  type = "string"
+  default = "200-399"
+}
+
+variable "tags" {
+  description = "tags for the distribution"
+  type        = "map"
+  description = "tags, just tags"
+}
+
+//additional listener specific vars
+variable "priority" {
+  description = "The priority for the rule. A listener can't have multiple rules with the same priority"
+}
+
+variable "condition_field" {
+  description = "The name of the field. Must be one of path-pattern for path based routing or host-header for host based routing. Accepts path-pattern, host-header"
+  type = "string"
+  default = "host-header"
+}
+
+variable "condition_values" {
+  description = "This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
+  type = "string"
+}
+
+/**
+ * Resources.
+ */
+
+ module "tf-aws-alb-target-group-bdcloud" {
+   source                           = "github.com/BuildDirect/tf-modules//tf-aws-alb-target-group?ref=0.1.13"
+   name                             = "${var.name}-tg"
+   port                             = "${var.port}"
+   protocol                         = "${var.protocol}"
+   vpc_id                           = "${var.vpc_id}"
+   health_check_protocol            = "${var.health_check_protocol}"
+   health_check_path                = "${var.health_check_path}"
+   health_check_port                = "${var.health_check_port}"
+   health_check_healthy_threshold   = "${var.health_check_healthy_threshold}"
+   health_check_unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+   health_check_timeout             = "${var.health_check_timeout}"
+   health_check_interval            = "${var.health_check_interval}"
+   health_check_matcher             = "${var.health_check_matcher}"
+   tags                             = "${var.tags}"
+ }
+
+ module "tf-aws-alb-listener-rule-80" {
+   source                  = "github.com/BuildDirect/tf-modules//tf-aws-alb-listener-rule?ref=0.1.11"
+   listener_arn            = "${var.listener_arn_80}"
+   priority                = "${var.priority}"
+   action_target_group_arn = "${module.tf-aws-alb-target-group-bdcloud.alb_target_group_arn}"
+   condition_field         = "${var.condition_field}"
+   condition_values        = "${var.condition_values}.bdcloud.ca"
+ }
+
+ module "tf-aws-alb-listener-rule-443" {
+   source                  = "github.com/BuildDirect/tf-modules//tf-aws-alb-listener-rule?ref=0.1.11"
+   listener_arn            = "${var.listener_arn_443}"
+   priority                = "${var.priority}"
+   action_target_group_arn = "${module.tf-aws-alb-target-group-bdcloud.alb_target_group_arn}"
+   condition_field         = "${var.condition_field}"
+   condition_values        = "${var.condition_values}.bdcloud.ca"
+ }
+
+/**
+ * Outputs.
+ */
+
+ //The name for the target group for tg bdcloud.ca
+ output "name" {
+   value = "${module.tf-aws-alb-target-group-bdcloud.alb_target_group_name}"
+ }
+
+ //The arn for the target group for tg bdcloud.ca
+ output "arn" {
+   value = "${module.tf-aws-alb-target-group-bdcloud.alb_target_group_arn}"
+ }

--- a/tg-listner/main.tf
+++ b/tg-listner/main.tf
@@ -17,6 +17,7 @@ variable "port" {
 
 variable "protocol" {
   description = "Protocol to use, HTTP or TCP"
+  default = "HTTP"
 }
 
 variable "vpc_id" {

--- a/tg-listner/main.tf
+++ b/tg-listner/main.tf
@@ -3,12 +3,11 @@
  * It is used by the service-tg module.
  */
 
+/**
+* Required Variables.
+*/
 variable "name" {
   description = "target group name, e.g cdn"
-}
-
-variable "environment" {
-  description = "Environment tag, e.g prod"
 }
 
 variable "port" {
@@ -24,63 +23,10 @@ variable "vpc_id" {
   description = "The ID of the VPC in which your targets are located"
 }
 
-variable "health_check_protocol" {
-  description = "The protocol that the load balancer uses when performing health checks on the targets. Accepts HTTP, HTTPS "
-  type = "string"
-  default = "HTTP"
-}
-variable "health_check_path" {
-  description = "The ping path destination where Elastic Load Balancing sends health check requests"
-  type = "string"
-  default = "/api/Heartbeats"
-}
-variable "health_check_port" {
-  description = "The port to use to connect with the target. Valid values are either ports 1-65536, or traffic-port"
-  type = "string"
-  default = "traffic-port"
-}
-variable "health_check_healthy_threshold" {
-  description = "The number of consecutive successful health checks that are required before an unhealthy target is considered healthy"
-  default = 2
-}
-variable "health_check_unhealthy_threshold" {
-  description = " The number of consecutive failed health checks that are required before a target is considered unhealthy"
-  default = 2
-}
-variable "health_check_timeout" {
-  description = "The number of seconds to wait for a response before considering that a health check has failed"
-  default = 5
-}
-variable "health_check_interval" {
-  description = "The approximate number of seconds between health checks for an individual target"
-  default = 30
-}
-variable "health_check_matcher" {
-  description = "The HTTP codes that a healthy target uses when responding to a health check. HTTP codes must be in Matcher data type"
-  type = "string"
-  default = "200-399"
-}
-
 variable "tags" {
   description = "tags for the distribution"
   type        = "map"
   description = "tags, just tags"
-}
-
-//additional listener specific vars
-variable "priority" {
-  description = "The priority for the rule. A listener can't have multiple rules with the same priority"
-}
-
-variable "condition_field" {
-  description = "The name of the field. Must be one of path-pattern for path based routing or host-header for host based routing. Accepts path-pattern, host-header"
-  type = "string"
-  default = "host-header"
-}
-
-variable "condition_values" {
-  description = "This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
-  type = "string"
 }
 
 variable "listener_arn_80" {
@@ -88,9 +34,71 @@ variable "listener_arn_80" {
   type = "string"
 }
 
+variable "priority" {
+  description = "The priority for the rule. A listener can't have multiple rules with the same priority"
+}
+
+variable "condition_values" {
+  description = "This should include the service name and the environment, there must be no trailing period (.); omit the root domain. For example: community.dev"
+  type = "string"
+}
+
 variable "listener_arn_443" {
   description = "arn of an aws_alb_listener"
   type = "string"
+}
+
+/**
+ * Options.
+ */
+variable "health_check_protocol" {
+  description = "The protocol that the load balancer uses when performing health checks on the targets. Accepts HTTP, HTTPS "
+  type = "string"
+  default = "HTTP"
+}
+
+variable "health_check_path" {
+  description = "The ping path destination where Elastic Load Balancing sends health check requests"
+  type = "string"
+  default = "/"
+}
+
+variable "health_check_port" {
+  description = "The port to use to connect with the target. Valid values are either ports 1-65536, or traffic-port"
+  type = "string"
+  default = "traffic-port"
+}
+
+variable "health_check_healthy_threshold" {
+  description = "The number of consecutive successful health checks that are required before an unhealthy target is considered healthy"
+  default = 2
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = " The number of consecutive failed health checks that are required before a target is considered unhealthy"
+  default = 2
+}
+
+variable "health_check_timeout" {
+  description = "The number of seconds to wait for a response before considering that a health check has failed"
+  default = 5
+}
+
+variable "health_check_interval" {
+  description = "The approximate number of seconds between health checks for an individual target"
+  default = 30
+}
+
+variable "health_check_matcher" {
+  description = "The HTTP codes that a healthy target uses when responding to a health check. HTTP codes must be in Matcher data type"
+  type = "string"
+  default = "200-399"
+}
+
+variable "condition_field" {
+  description = "The name of the field. Must be one of path-pattern for path based routing or host-header for host based routing. Accepts path-pattern, host-header"
+  type = "string"
+  default = "host-header"
 }
 
 /**

--- a/tg-listner/main.tf
+++ b/tg-listner/main.tf
@@ -83,6 +83,16 @@ variable "condition_values" {
   type = "string"
 }
 
+variable "listener_arn_80" {
+  description = "arn of an aws_alb_listener"
+  type = "string"
+}
+
+variable "listener_arn_443" {
+  description = "arn of an aws_alb_listener"
+  type = "string"
+}
+
 /**
  * Resources.
  */


### PR DESCRIPTION
sub module service-tg, and tg-listener modules created
tg-listner: creates a listener rule and a target group
service-tg: creates a service, a task definition, a tg and matching listener rule